### PR TITLE
fix: add store service cleanup

### DIFF
--- a/libs/select-snapshot/src/lib/core/internals/select-snapshot.ts
+++ b/libs/select-snapshot/src/lib/core/internals/select-snapshot.ts
@@ -53,7 +53,7 @@ export function defineSelectSnapshotProperties(
         );
         // Don't use the `directiveInject` here as it works ONLY
         // during view creation.
-        store = store || getStore();
+        store = getStore();
         return store.selectSnapshot(selector);
       },
       enumerable: true,

--- a/libs/select-snapshot/src/lib/core/internals/static-injector.ts
+++ b/libs/select-snapshot/src/lib/core/internals/static-injector.ts
@@ -8,6 +8,7 @@ class NgxsSelectSnapshotModuleIsNotImported extends Error {
 }
 
 let injector: Injector | null = null;
+let store: Store | null = null;
 
 function assertDefined<T>(actual: T | null | undefined): asserts actual is T {
   if (actual == null) {
@@ -25,9 +26,10 @@ export function setInjector(parentInjector: Injector): void {
  */
 export function clearInjector(): void {
   injector = null;
+  store = null;
 }
 
 export function getStore(): never | Store {
   assertDefined(injector);
-  return injector!.get(Store);
+  return store || injector!.get(Store);
 }

--- a/libs/select-snapshot/src/lib/core/internals/static-injector.ts
+++ b/libs/select-snapshot/src/lib/core/internals/static-injector.ts
@@ -31,5 +31,6 @@ export function clearInjector(): void {
 
 export function getStore(): never | Store {
   assertDefined(injector);
-  return store || injector!.get(Store);
+  store = store || injector!.get(Store);
+  return store;
 }

--- a/libs/select-snapshot/src/lib/select-snapshot.spec.ts
+++ b/libs/select-snapshot/src/lib/select-snapshot.spec.ts
@@ -217,29 +217,29 @@ describe('SelectSnapshot', () => {
     expect(message).toEqual("Cannot read properties of undefined (reading 'here')");
   });
 
+  // Arrange
+  class Increment {
+    public static type = '[Counter] Increment';
+  }
+
+  @State({
+    name: 'counter',
+    defaults: 0,
+  })
+  @Injectable()
+  class CounterState {
+    @Action(Increment)
+    increment({ setState, getState }: StateContext<number>): void {
+      setState(getState() + 1);
+    }
+  }
+
+  @Component({ template: '' })
+  class TestComponent {
+    @SelectSnapshot(CounterState) counter!: number;
+  }
+
   it('should get the correct snapshot after dispatching multiple actions', () => {
-    // Arrange
-    class Increment {
-      public static type = '[Counter] Increment';
-    }
-
-    @State({
-      name: 'counter',
-      defaults: 0,
-    })
-    @Injectable()
-    class CounterState {
-      @Action(Increment)
-      increment({ setState, getState }: StateContext<number>): void {
-        setState(getState() + 1);
-      }
-    }
-
-    @Component({ template: '' })
-    class TestComponent {
-      @SelectSnapshot(CounterState) counter!: number;
-    }
-
     // Act
     TestBed.configureTestingModule({
       imports: [
@@ -260,6 +260,27 @@ describe('SelectSnapshot', () => {
     store.dispatch(new Increment());
 
     expect(componentInstance.counter).toBe(4);
+  });
+
+  it('should get the correct state after destroying the module', () => {
+    // Act
+    TestBed.configureTestingModule({
+      imports: [
+        NgxsModule.forRoot([CounterState], { developmentMode: true }),
+        NgxsSelectSnapshotModule.forRoot(),
+      ],
+      declarations: [TestComponent],
+    });
+
+    // Assert
+    const { componentInstance } = TestBed.createComponent(TestComponent);
+    const store: Store = TestBed.inject<Store>(Store);
+
+    expect(componentInstance.counter).toBe(0);
+
+    store.dispatch(new Increment());
+
+    expect(componentInstance.counter).toBe(1);
   });
 
   @State<any>({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Reference to Store service object keeps after the module is destroyed.

Issue Number: #116

## What is the new behavior?
Reference to Store service object clears after the module is destroyed.
(same behavior as with "injector" reference)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
