### PR TITLE
docs: clarify the behavior of `@SelectSnapshot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ export class AppModule {}
 
 ### SelectSnapshot
 
-`@SelectSnapshot` decorator should be used similarly to the `@Select` decorator. It will decorate the property to always return the selected value, whereas `@Select` decorates properties to return observable. Given the following example:
+`@SelectSnapshot` decorator should be used similarly to the `@Select` decorator. It will decorate the property to always return the latest selected value, whereas `@Select` decorates properties to return observable. Given the following example:
 
 ```ts
 import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
@@ -114,6 +114,16 @@ export class TokenInterceptor {
 ```
 
 We don't have to inject the `Store` and call the `selectSnapshot`.
+
+Behind the scenes, `@SelectSnapshot` sets up a getter that calls `store.selectSnapshot` with the provided selector on each access.
+In the above example, it roughly equates to setting up this property getter:
+
+```ts
+get token(): string | null {
+  // ... inject `Store` in variable `store`
+  return store.selectSnapshot(AuthState.token);
+}
+```
 
 ### ViewSelectSnapshot
 


### PR DESCRIPTION
Update the documentation to clarify the fact that the `@SelectSnapshot` decorator sets up a property getter that will select the latest value on each access.

Closes #155

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

Issue Number: [#155]
